### PR TITLE
Move onwer logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "eslint": "^8",
         "eslint-config-next": "14.1.0",
         "postcss": "^8",
+        "prettier-plugin-prisma": "^5.0.0",
         "prisma": "^5.12.1",
         "tailwindcss": "^3.3.0",
         "typescript": "^5"
@@ -2457,6 +2458,12 @@
       "dependencies": {
         "@prisma/debug": "5.12.1"
       }
+    },
+    "node_modules/@prisma/prisma-schema-wasm": {
+      "version": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584",
+      "resolved": "https://registry.npmjs.org/@prisma/prisma-schema-wasm/-/prisma-schema-wasm-4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584.tgz",
+      "integrity": "sha512-JFdsnSgBPN8reDTLOI9Vh/6ccCb2aD1LbY/LWQnkcIgNo6IdpzvuM+qRVbBuA6IZP2SdqQI8Lu6RL2P8EFBQUA==",
+      "dev": true
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -8633,6 +8640,38 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-prisma": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-prisma/-/prettier-plugin-prisma-5.0.0.tgz",
+      "integrity": "sha512-jTJV04D9+yF7ziOOMs7CJe4ijgAH7DEGjt0SAWAToGNRy1H6BEhvcKA2UQH6gC6KVW5zeeOSAvsoiDDTt9oKXg==",
+      "dev": true,
+      "dependencies": {
+        "@prisma/prisma-schema-wasm": "4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "prettier": ">=2 || >=3"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.1.0",
     "postcss": "^8",
+    "prettier-plugin-prisma": "^5.0.0",
     "prisma": "^5.12.1",
     "tailwindcss": "^3.3.0",
     "typescript": "^5"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,11 +56,11 @@ enum Colour {
 model Note {
   id          String   @id @default(uuid())
   title       String
-  createdAt   DateTime @default(now())
-  lastUpdate  DateTime @default(now())
-  isFavourite Boolean  @default(false)
-  isArchived  Boolean  @default(false)
-  isPublic    Boolean  @default(false)
+  createdAt   DateTime @default(now()) @map("created_at")
+  lastUpdate  DateTime @default(now()) @map("last_update")
+  isFavourite Boolean  @default(false) @map("is_favourite")
+  isArchived  Boolean  @default(false) @map("is_archived")
+  isPublic    Boolean  @default(false) @map("is_public")
   owner       User     @relation(fields: [userId], references: [id])
   content     String
   colour      Colour

--- a/src/app/(notes)/archived/[id]/page.tsx
+++ b/src/app/(notes)/archived/[id]/page.tsx
@@ -1,38 +1,27 @@
 import NotFound from '@/app/not-found';
 import NotVisibleWarning from '@/components/NotVisibleWarning';
 import NoteEditor from '@/components/Note/NoteEditor';
-import NoteHeader, { Owner } from '@/components/Note/NoteHeader';
+import NoteHeader from '@/components/Note/NoteHeader';
 import { currentUser, getNoteById } from '@/queries/note';
-import { getUserById } from '@/queries/user';
 
 type Props = { params: { id: string } };
 
 export default async function Archived({ params }: Props) {
   const note = await getNoteById(params.id);
   if (!note) return <NotFound />;
-  const { content, title, createdAt, id, lastUpdate, userId, isPublic } = note;
-  const owner = await getUserById(userId);
-  if (!owner) return;
+  const { content, title, createdAt, id, lastUpdate, isPublic, owner } = note;
 
   const user = await currentUser();
   const isNoteVisible = user?.id === owner.id || isPublic;
   if (!isNoteVisible) return <NotVisibleWarning />;
 
-  const ownerResumed: Owner = {
-    name: owner.name,
-    id: owner.id,
-  };
-
   return (
     <div className='w-full pb-6 overflow-y-clip flex flex-col'>
-      <NoteEditor
-        content={content}
-        owner={owner.id}
-      >
+      <NoteEditor content={content} owner={owner.id}>
         <NoteHeader
           title={title}
           date={createdAt}
-          owner={ownerResumed}
+          owner={owner}
           id={id}
           lastUpdate={lastUpdate || createdAt}
         />

--- a/src/app/(notes)/favourites/[id]/page.tsx
+++ b/src/app/(notes)/favourites/[id]/page.tsx
@@ -1,38 +1,27 @@
 import NotFound from '@/app/not-found';
 import NotVisibleWarning from '@/components/NotVisibleWarning';
 import NoteEditor from '@/components/Note/NoteEditor';
-import NoteHeader, { Owner } from '@/components/Note/NoteHeader';
+import NoteHeader from '@/components/Note/NoteHeader';
 import { currentUser, getNoteById } from '@/queries/note';
-import { getUserById } from '@/queries/user';
 
 type Props = { params: { id: string } };
 
 export default async function Favourite({ params }: Props) {
   const note = await getNoteById(params.id);
   if (!note) return <NotFound />;
-  const { content, title, createdAt, id, lastUpdate, userId, isPublic } = note;
-  const owner = await getUserById(userId);
-  if (!owner) return;
+  const { content, title, createdAt, id, lastUpdate, isPublic, owner } = note;
 
   const user = await currentUser();
   const isNoteVisible = user?.id === owner.id || isPublic;
   if (!isNoteVisible) return <NotVisibleWarning />;
 
-  const ownerResumed: Owner = {
-    name: owner.name,
-    id: owner.id,
-  };
-
   return (
     <div className='w-full pb-6 overflow-y-clip flex flex-col'>
-      <NoteEditor
-        owner={owner.id}
-        content={content}
-      >
+      <NoteEditor owner={owner.id} content={content}>
         <NoteHeader
           title={title}
           date={createdAt}
-          owner={ownerResumed}
+          owner={owner}
           id={id}
           lastUpdate={lastUpdate || createdAt}
         />

--- a/src/app/(notes)/notes/[id]/page.tsx
+++ b/src/app/(notes)/notes/[id]/page.tsx
@@ -1,9 +1,8 @@
 import NotFound from '@/app/not-found';
 import NotVisibleWarning from '@/components/NotVisibleWarning';
 import NoteEditor from '@/components/Note/NoteEditor';
-import NoteHeader, { Owner } from '@/components/Note/NoteHeader';
+import NoteHeader from '@/components/Note/NoteHeader';
 import { currentUser, getNoteById } from '@/queries/note';
-import { getUserById } from '@/server/queries/user';
 
 type Props = { params: { id: string } };
 
@@ -12,30 +11,20 @@ export default async function NotePage({ params }: Props) {
 
   const note = await getNoteById(id);
   if (!note) return <NotFound />;
-  const owner = await getUserById(note.userId);
-  if (!owner) return <NotFound />;
 
-  const { content, title, createdAt, lastUpdate, isPublic } = note;
+  const { content, title, createdAt, lastUpdate, isPublic, owner } = note;
 
   const user = await currentUser();
   const isNoteVisible = user?.id === owner.id || isPublic;
   if (!isNoteVisible) return <NotVisibleWarning />;
 
-  const resumedOwner: Owner = {
-    name: owner.name,
-    id: owner.id,
-  };
-
   return (
-    <NoteEditor
-      owner={owner.id}
-      content={content}
-    >
+    <NoteEditor owner={owner.id} content={content}>
       <NoteHeader
         id={id}
         title={title}
         date={createdAt}
-        owner={resumedOwner}
+        owner={owner}
         lastUpdate={lastUpdate || createdAt}
       />
     </NoteEditor>

--- a/src/components/Note/NoteHeader.tsx
+++ b/src/components/Note/NoteHeader.tsx
@@ -16,7 +16,7 @@ import StatusTooltip from '../StatusTooltip';
 import { headers } from 'next/headers';
 import PublishNoteDialog from './PublishNoteDialog';
 
-export type Owner = {
+type Owner = {
   name: string | null;
   id: string;
 };

--- a/src/server/actions/note.ts
+++ b/src/server/actions/note.ts
@@ -190,6 +190,7 @@ export async function togglePublishState(id: string, currentState: boolean) {
 export const getNote = cache(async (id: string) => {
   try {
     const note = await db.note.findUnique({ where: { id } });
+
     return note;
   } catch (error) {
     return null;

--- a/src/server/db/migration.sql
+++ b/src/server/db/migration.sql
@@ -1,0 +1,20 @@
+ALTER TABLE "notes"
+    ADD COLUMN "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ADD COLUMN "is_archived" BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN "is_favourite" BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN "is_public" BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN "last_update" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE "notes" SET
+    "created_at" = "createdAt",
+    "is_archived" = "isArchived",
+    "is_favourite" = "isFavourite",
+    "is_public" = "isPublic",
+    "last_update" = "lastUpdate";
+
+ALTER TABLE "notes"
+    DROP COLUMN "createdAt",
+    DROP COLUMN "isArchived",
+    DROP COLUMN "isFavourite",
+    DROP COLUMN "isPublic",
+    DROP COLUMN "lastUpdate";

--- a/src/server/queries/note.ts
+++ b/src/server/queries/note.ts
@@ -11,7 +11,10 @@ export const currentUser = cache(async () => {
 
 export const getNoteById = cache(async (id: string) => {
   try {
-    const note = await db.note.findUnique({ where: { id } });
+    const note = await db.note.findUnique({
+      where: { id },
+      include: { owner: { select: { name: true, id: true } } },
+    });
     return note;
   } catch (error) {
     return null;


### PR DESCRIPTION
## Move owner logic to improve performance on Note loading

### Description
I observed that the initial loading of notes was taking longer than expected. To optimize performance, I have removed the getUserById function calls from pages related to notes.

### Changes

- Removed getUserById from notes pages.
- Renamed several database fields to snake_case, such as changing createdAt to created_at. For detailed changes, refer to `src/server/db/migration.sql`.